### PR TITLE
Add a code metric option for Branches

### DIFF
--- a/configuration.html
+++ b/configuration.html
@@ -196,6 +196,7 @@
                     <select id="coverage-measurement-dropdown">                                              
                         <option value="Blocks">Blocks</option>
                         <option value="Branch">Branch</option>
+                        <option value="Branches">Branches</option>
                         <option value="Class">Class</option>
                         <option value="Complexity">Complexity</option>
                         <option value="Instruction">Instruction</option>


### PR DESCRIPTION
The Branches option enables reporting on branch code coverage captured in [Cobertura](https://github.com/cobertura/cobertura/blob/db3bedf3334d8f35bad7ca3c6f4d777be6a09fc5/cobertura/src/site/htdocs/xml/coverage-04.dtd#L12) code coverage results.

![image](https://user-images.githubusercontent.com/13053902/28227980-76914bd8-68aa-11e7-936a-486bc64c1d0e.png)